### PR TITLE
Adjust color palette to white and Gloria Blue

### DIFF
--- a/app/src/main/java/com/ml/shubham0204/docqa/ui/screens/chat/ChatScreen.kt
+++ b/app/src/main/java/com/ml/shubham0204/docqa/ui/screens/chat/ChatScreen.kt
@@ -52,6 +52,7 @@ import com.ml.shubham0204.docqa.R
 import com.ml.shubham0204.docqa.ui.components.AppAlertDialog
 import com.ml.shubham0204.docqa.ui.components.createAlertDialog
 import com.ml.shubham0204.docqa.ui.theme.DocQATheme
+import com.ml.shubham0204.docqa.ui.theme.GloriaBlue
 import dev.jeziellago.compose.markdowntext.MarkdownText
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -257,7 +258,7 @@ private fun QueryInput(onEvent: (ChatScreenUIEvent) -> Unit) {
         )
         Spacer(modifier = Modifier.width(8.dp))
         IconButton(
-            modifier = Modifier.background(Color.Blue, CircleShape),
+            modifier = Modifier.background(GloriaBlue, CircleShape),
             onClick = {
                 keyboardController?.hide()
 

--- a/app/src/main/java/com/ml/shubham0204/docqa/ui/screens/docs/DocsScreen.kt
+++ b/app/src/main/java/com/ml/shubham0204/docqa/ui/screens/docs/DocsScreen.kt
@@ -60,6 +60,7 @@ import com.ml.shubham0204.docqa.domain.readers.Readers
 import com.ml.shubham0204.docqa.ui.components.AppAlertDialog
 import com.ml.shubham0204.docqa.ui.components.createAlertDialog
 import com.ml.shubham0204.docqa.ui.theme.DocQATheme
+import com.ml.shubham0204.docqa.ui.theme.GloriaBlue
 
 private val showDocDetailDialog = mutableStateOf(false)
 private val dialogDoc = mutableStateOf<Document?>(null)
@@ -357,7 +358,7 @@ private fun DocDetailDialog() {
                         modifier = Modifier.fillMaxWidth(),
                     ) {
                         Button(
-                            colors = ButtonDefaults.buttonColors(containerColor = Color.Blue),
+                            colors = ButtonDefaults.buttonColors(containerColor = GloriaBlue),
                             onClick = {
                                 val sendIntent: Intent =
                                     Intent().apply {
@@ -372,7 +373,7 @@ private fun DocDetailDialog() {
                             Text(text = "Share Text")
                         }
                         Button(
-                            colors = ButtonDefaults.buttonColors(containerColor = Color.Blue),
+                            colors = ButtonDefaults.buttonColors(containerColor = GloriaBlue),
                             onClick = { isVisible = false },
                         ) {
                             Text(text = "Close")

--- a/app/src/main/java/com/ml/shubham0204/docqa/ui/theme/Color.kt
+++ b/app/src/main/java/com/ml/shubham0204/docqa/ui/theme/Color.kt
@@ -2,6 +2,7 @@ package com.ml.shubham0204.docqa.ui.theme
 
 import androidx.compose.ui.graphics.Color
 
+val GloriaBlue = Color(0xFF008ECC)
 val Purple80 = Color(0xFFD0BCFF)
 val PurpleGrey80 = Color(0xFFCCC2DC)
 val Pink80 = Color(0xFFEFB8C8)

--- a/app/src/main/java/com/ml/shubham0204/docqa/ui/theme/Theme.kt
+++ b/app/src/main/java/com/ml/shubham0204/docqa/ui/theme/Theme.kt
@@ -8,29 +8,35 @@ import androidx.compose.material3.dynamicDarkColorScheme
 import androidx.compose.material3.dynamicLightColorScheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 
 private val DarkColorScheme =
     darkColorScheme(
-        primary = Purple80,
-        secondary = PurpleGrey80,
-        tertiary = Pink80,
+        primary = GloriaBlue,
+        secondary = GloriaBlue,
+        tertiary = GloriaBlue,
+        background = Color.White,
+        surface = Color.White,
+        onPrimary = Color.White,
+        onSecondary = Color.White,
+        onTertiary = Color.White,
+        onBackground = GloriaBlue,
+        onSurface = GloriaBlue,
     )
 
 private val LightColorScheme =
     lightColorScheme(
-        primary = Purple40,
-        secondary = PurpleGrey40,
-        tertiary = Pink40,
-        /* Other default colors to override
-        background = Color(0xFFFFFBFE),
-        surface = Color(0xFFFFFBFE),
+        primary = GloriaBlue,
+        secondary = GloriaBlue,
+        tertiary = GloriaBlue,
+        background = Color.White,
+        surface = Color.White,
         onPrimary = Color.White,
         onSecondary = Color.White,
         onTertiary = Color.White,
-        onBackground = Color(0xFF1C1B1F),
-        onSurface = Color(0xFF1C1B1F),
-         */
+        onBackground = GloriaBlue,
+        onSurface = GloriaBlue,
     )
 
 @Composable

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -7,4 +7,5 @@
     <color name="teal_700">#FF018786</color>
     <color name="black">#FF000000</color>
     <color name="white">#FFFFFFFF</color>
+    <color name="gloria_blue">#FF008ECC</color>
 </resources>


### PR DESCRIPTION
## Summary
- add `GloriaBlue` color constant
- switch theme color scheme to white and Gloria Blue
- apply Gloria Blue in chat and docs screens
- expose color resource for `gloria_blue`

## Testing
- `./gradlew tasks --all` *(fails: Unable to download due to network restriction)*

------
https://chatgpt.com/codex/tasks/task_e_686cbc9cfc2c83309c3612958f893730