### PR TITLE
Add clickable source link for responses

### DIFF
--- a/app/src/main/java/com/ml/shubham0204/docqa/data/DocumentsDB.kt
+++ b/app/src/main/java/com/ml/shubham0204/docqa/data/DocumentsDB.kt
@@ -26,4 +26,10 @@ class DocumentsDB {
             .flowOn(Dispatchers.IO)
 
     fun getDocsCount(): Long = docsBox.count()
+
+    fun getDocumentByFileName(fileName: String): Document? =
+        docsBox
+            .query(Document_.docFileName.equal(fileName))
+            .build()
+            .findFirst()
 }

--- a/app/src/main/java/com/ml/shubham0204/docqa/ui/components/AppDocDetailDialog.kt
+++ b/app/src/main/java/com/ml/shubham0204/docqa/ui/components/AppDocDetailDialog.kt
@@ -1,0 +1,80 @@
+package com.ml.shubham0204.docqa.ui.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Dialog
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import com.ml.shubham0204.docqa.ui.theme.GloriaBlue
+
+private val dialogVisible = mutableStateOf(false)
+private val dialogFileName = mutableStateOf("")
+private val dialogText = mutableStateOf("")
+
+@Composable
+fun AppDocDetailDialog() {
+    val isVisible by remember { dialogVisible }
+    if (isVisible) {
+        Dialog(onDismissRequest = { /* non cancellable */ }) {
+            Box(
+                contentAlignment = Alignment.Center,
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .background(Color.White, shape = RoundedCornerShape(8.dp))
+                        .padding(24.dp),
+            ) {
+                Column(horizontalAlignment = Alignment.Start) {
+                    Text(text = dialogFileName.value)
+                    Spacer(modifier = Modifier.height(8.dp))
+                    Text(
+                        text = dialogText.value,
+                        modifier =
+                            Modifier.height(200.dp).verticalScroll(rememberScrollState()),
+                    )
+                    Spacer(modifier = Modifier.height(8.dp))
+                    Row(
+                        horizontalArrangement = Arrangement.End,
+                        modifier = Modifier.fillMaxWidth(),
+                    ) {
+                        Button(
+                            colors = ButtonDefaults.buttonColors(containerColor = GloriaBlue),
+                            onClick = { hideDocDetailDialog() },
+                        ) {
+                            Text(text = "Close")
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+fun showDocDetailDialog(fileName: String, text: String) {
+    dialogFileName.value = fileName
+    dialogText.value = text
+    dialogVisible.value = true
+}
+
+fun hideDocDetailDialog() {
+    dialogVisible.value = false
+}

--- a/app/src/main/java/com/ml/shubham0204/docqa/ui/screens/chat/ChatScreen.kt
+++ b/app/src/main/java/com/ml/shubham0204/docqa/ui/screens/chat/ChatScreen.kt
@@ -2,6 +2,7 @@ package com.ml.shubham0204.docqa.ui.screens.chat
 
 import android.content.Intent
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -50,6 +51,8 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.ml.shubham0204.docqa.R
 import com.ml.shubham0204.docqa.ui.components.AppAlertDialog
+import com.ml.shubham0204.docqa.ui.components.AppDocDetailDialog
+import com.ml.shubham0204.docqa.ui.components.showDocDetailDialog
 import com.ml.shubham0204.docqa.ui.components.createAlertDialog
 import com.ml.shubham0204.docqa.ui.theme.DocQATheme
 import com.ml.shubham0204.docqa.ui.theme.GloriaBlue
@@ -107,6 +110,7 @@ fun ChatScreen(
                 }
             }
             AppAlertDialog()
+            AppDocDetailDialog()
         }
     }
 }
@@ -156,10 +160,16 @@ private fun ColumnScope.QALayout(screenUiState: ChatScreenUIState) {
                 item {
                     if (!screenUiState.isGeneratingResponse) {
                         Spacer(modifier = Modifier.height(16.dp))
+                        val fileName = screenUiState.retrievedContextList.firstOrNull()?.fileName
                         Column(
                             modifier =
                                 Modifier
                                     .background(Color.White, RoundedCornerShape(16.dp))
+                                    .clickable {
+                                        fileName?.let {
+                                            onScreenEvent(ChatScreenUIEvent.OnResponseClick(it))
+                                        }
+                                    }
                                     .padding(24.dp)
                                     .fillMaxWidth(),
                         ) {
@@ -194,6 +204,17 @@ private fun ColumnScope.QALayout(screenUiState: ChatScreenUIState) {
                                         tint = Color.Black,
                                     )
                                 }
+                            }
+                            fileName?.let {
+                                Spacer(modifier = Modifier.height(4.dp))
+                                Text(
+                                    text = "Source: $it",
+                                    color = Color.Blue,
+                                    fontSize = 12.sp,
+                                    modifier = Modifier.clickable {
+                                        onScreenEvent(ChatScreenUIEvent.OnResponseClick(it))
+                                    },
+                                )
                             }
                         }
                         Spacer(modifier = Modifier.height(8.dp))

--- a/app/src/main/java/com/ml/shubham0204/docqa/ui/screens/chat/ChatViewModel.kt
+++ b/app/src/main/java/com/ml/shubham0204/docqa/ui/screens/chat/ChatViewModel.kt
@@ -9,6 +9,7 @@ import com.ml.shubham0204.docqa.data.DocumentsDB
 import com.ml.shubham0204.docqa.data.RetrievedContext
 import com.ml.shubham0204.docqa.domain.GemmaLocalAPI
 import com.ml.shubham0204.docqa.domain.SentenceEmbeddingProvider
+import com.ml.shubham0204.docqa.ui.components.showDocDetailDialog
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.channels.Channel
@@ -20,6 +21,8 @@ import org.koin.android.annotation.KoinViewModel
 
 sealed interface ChatScreenUIEvent {
     data object OnOpenDocsClick : ChatScreenUIEvent
+
+    data class OnResponseClick(val fileName: String) : ChatScreenUIEvent
 
     sealed class ResponseGeneration {
         data class Start(
@@ -106,6 +109,12 @@ class ChatViewModel(
             is ChatScreenUIEvent.OnOpenDocsClick -> {
                 viewModelScope.launch {
                     _navEventChannel.send(ChatNavEvent.ToDocsScreen)
+                }
+            }
+
+            is ChatScreenUIEvent.OnResponseClick -> {
+                documentsDB.getDocumentByFileName(event.fileName)?.let { doc ->
+                    showDocDetailDialog(doc.docFileName, doc.docText)
                 }
             }
 


### PR DESCRIPTION
## Summary
- add method to fetch a document by filename
- introduce `AppDocDetailDialog` component
- allow opening document details from chat answers
- display the document source below the response

## Testing
- `./gradlew build` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_686cd17273c48330a571f6fee55aec1b