### PR TITLE
Fix dialog import and missing event parameter

### DIFF
--- a/app/src/main/java/com/ml/shubham0204/docqa/ui/components/AppDocDetailDialog.kt
+++ b/app/src/main/java/com/ml/shubham0204/docqa/ui/components/AppDocDetailDialog.kt
@@ -14,8 +14,8 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
-import androidx.compose.material3.Dialog
 import androidx.compose.material3.Text
+import androidx.compose.ui.window.Dialog
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf

--- a/app/src/main/java/com/ml/shubham0204/docqa/ui/screens/chat/ChatScreen.kt
+++ b/app/src/main/java/com/ml/shubham0204/docqa/ui/screens/chat/ChatScreen.kt
@@ -104,7 +104,7 @@ fun ChatScreen(
                         .fillMaxWidth(),
             ) {
                 Column {
-                    QALayout(screenUiState)
+                    QALayout(screenUiState, onScreenEvent)
                     Spacer(modifier = Modifier.height(8.dp))
                     QueryInput(onScreenEvent)
                 }
@@ -116,7 +116,10 @@ fun ChatScreen(
 }
 
 @Composable
-private fun ColumnScope.QALayout(screenUiState: ChatScreenUIState) {
+private fun ColumnScope.QALayout(
+    screenUiState: ChatScreenUIState,
+    onScreenEvent: (ChatScreenUIEvent) -> Unit,
+) {
     val context = LocalContext.current
     Column(
         modifier =


### PR DESCRIPTION
## Summary
- fix dialog import to use compose ui window
- forward onScreenEvent into QALayout so click handlers compile

## Testing
- `./gradlew build` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_686cd54a91608330a74cc31a744cdf76